### PR TITLE
Default build directory: ./build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ in the standard format into the local directory:
 
 .. code:: bash
 
-    $ documentation-builder --source-path .  # Build markdown documentation from the current directory
+    $ documentation-builder  # Build markdown documentation from the current directory
     # or
     $ documentation-builder --repository git@github.com:juju/docs.git  # Build documentation from remote repository
 
@@ -33,7 +33,7 @@ Optional arguments:
         --source-path {dirpath}           `# Path to the folder containing markdown files (default: .)`
         --source-media-dir {dirpath}      `# Path to the folder containing media files (default: ./media)`
         --source-context-file {filepath}  `# A file containing the context object for building the templates (default: ./context.yaml)`
-        --output-path {dirpath}           `# Destination path for the built HTML files (default: .)`
+        --output-path {dirpath}           `# Destination path for the built HTML files (default: ./html)`
         --output-media-dir {dirpath}      `# Where to put media files (default: ./media)`
         --template-path {filepath}        `# Path to an alternate wrapping template for the built HTML files`
         --media-url {prefix}              `# Prefix for linking to media inside the built HTML files (default: Relative path to built media location, e.g.: ../media)`

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Optional arguments:
         --source-path {dirpath}           `# Path to the folder containing markdown files (default: .)`
         --source-media-dir {dirpath}      `# Path to the folder containing media files (default: ./media)`
         --source-context-file {filepath}  `# A file containing the context object for building the templates (default: ./context.yaml)`
-        --output-path {dirpath}           `# Destination path for the built HTML files (default: ./html)`
+        --output-path {dirpath}           `# Destination path for the built HTML files (default: ./build)`
         --output-media-dir {dirpath}      `# Where to put media files (default: ./media)`
         --template-path {filepath}        `# Path to an alternate wrapping template for the built HTML files`
         --media-url {prefix}              `# Prefix for linking to media inside the built HTML files (default: Relative path to built media location, e.g.: ../media)`

--- a/ubuntudesign/documentation_builder/cli.py
+++ b/ubuntudesign/documentation_builder/cli.py
@@ -50,7 +50,7 @@ def parse_arguments():
     )
     parser.add_argument(
         '--output-path',
-        default="html",
+        default="build",
         help="Destination path for the built HTML files (default: .)"
     )
     parser.add_argument(

--- a/ubuntudesign/documentation_builder/cli.py
+++ b/ubuntudesign/documentation_builder/cli.py
@@ -35,6 +35,7 @@ def parse_arguments():
     )
     parser.add_argument(
         '--source-path',
+        default='.',
         help="Path to the folder containing markdown files (default: .)"
     )
     parser.add_argument(
@@ -79,17 +80,7 @@ def parse_arguments():
         help="Don't clean up temporary directory after cloning repository"
     )
 
-    arguments = parser.parse_args()
-
-    if not arguments.source_path:
-        if not arguments.repository:
-            parser.error(
-                "At least one of --repository or --source-path is required."
-            )
-        else:
-            arguments.source_path = '.'
-
-    return arguments
+    return parser.parse_args()
 
 
 def preprocess_files(dir_path, preprocessor_string):

--- a/ubuntudesign/documentation_builder/cli.py
+++ b/ubuntudesign/documentation_builder/cli.py
@@ -49,7 +49,7 @@ def parse_arguments():
     )
     parser.add_argument(
         '--output-path',
-        default=".",
+        default="html",
         help="Destination path for the built HTML files (default: .)"
     )
     parser.add_argument(


### PR DESCRIPTION
- Make `./html` the default output destination
- Allow `documentation-builder` without any options to build the current directory again

Fixes #2