### PR TITLE
Add __version__ property

### DIFF
--- a/ubuntudesign/documentation_builder/__init__.py
+++ b/ubuntudesign/documentation_builder/__init__.py
@@ -1,0 +1,4 @@
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution("ubuntudesign.documentation_builder").version
+


### PR DESCRIPTION
So that people can query which version of the module is installed:

``` bash
from ubuntudesign import documentation_builder

assert documentation_builder.__version__.split('.') > ['0', '3', '0']
```