### PR TITLE
--ignore-file option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,3 +39,4 @@ Optional arguments:
         --media-url {prefix}              `# Prefix for linking to media inside the built HTML files (default: Relative path to built media location, e.g.: ../media)`
         --no-link-extensions              `# Don't include '.html' extension in internal links`
         --no-cleanup                      `# Don't clean up temporary directory after cloning repository`
+        --ignore-file                     `# Filename of a markdown files to ignore and not parse into HTML. Can be declared multiple times. (default: README.md)`

--- a/ubuntudesign/documentation_builder/build.py
+++ b/ubuntudesign/documentation_builder/build.py
@@ -105,6 +105,7 @@ class Builder:
         self.global_context = global_context
         self.media_url = media_url
         self.no_link_extensions = no_link_extensions
+        self.ignore_files = ignore_files
 
     def build_files(self):
         """
@@ -136,6 +137,10 @@ class Builder:
             path.join(self.source_path, '**/*.md'),
             recursive=True
         ):
+            for ignore_name in ignore_files:
+                if ('/' + filepath).endswith(ignore_name):
+                    continue
+
             self.build_file(filepath)
 
     def build_file(self, source_filepath):
@@ -212,7 +217,8 @@ def build(
     template_path,
     media_url,
     no_link_extensions,
-    no_cleanup
+    no_cleanup,
+    ignore_files
 ):
     with open(template_path or default_template) as template_file:
         template = Template(template_file.read())
@@ -247,7 +253,8 @@ def build(
             template=template,
             global_context=global_context,
             media_url=media_url,
-            no_link_extensions=no_link_extensions
+            no_link_extensions=no_link_extensions,
+            ignore_files=ignore_files
         )
         builder.build_files()
     finally:

--- a/ubuntudesign/documentation_builder/cli.py
+++ b/ubuntudesign/documentation_builder/cli.py
@@ -79,6 +79,16 @@ def parse_arguments():
         action='store_true',
         help="Don't clean up temporary directory after cloning repository"
     )
+    parser.add_argument(
+        '--ignore-file',
+        action='append',
+        default=['README.md'],
+        dest='ignore_files',
+        help=(
+            "Filename of a markdown file to ignore and not parse into HTML. "
+            "Can be declared multiple times."
+        )
+    )
 
     return parser.parse_args()
 


### PR DESCRIPTION
A new option for ignoring markdown files. Defaults to ignoring README.md.