### PR TITLE
Change context.yaml to metadata.yaml

### DIFF
--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -178,6 +178,7 @@ class Builder:
         output_path,
         output_media_path,
         template,
+        site_root,
         media_url,
         no_link_extensions,
         quiet
@@ -187,6 +188,7 @@ class Builder:
         self.output_path = output_path
         self.output_media_path = output_media_path
         self.template = template
+        self.site_root = site_root
         self.media_url = media_url
         self.no_link_extensions = no_link_extensions
         self.quiet = quiet
@@ -307,6 +309,10 @@ class Builder:
         metadata = self._build_metadata(source_filepath, output_filepath)
         metadata.update(local_metadata)
         metadata['content'] = html_content
+
+        if self.site_root:
+            metadata['site_root'] = self.site_root
+
         html_document = self.template.render(metadata)
 
         # Fixup internal references
@@ -441,6 +447,7 @@ def build(
     output_path='build',
     output_media_path='build/media',
     template_path=None,
+    site_root=None,
     media_url=None,
     no_link_extensions=False,
     no_cleanup=False,
@@ -466,6 +473,7 @@ def build(
             output_path=output_path,
             output_media_path=output_media_path,
             template=template,
+            site_root=site_root,
             media_url=media_url,
             no_link_extensions=no_link_extensions,
             quiet=quiet

--- a/ubuntudesign/documentation_builder/cli.py
+++ b/ubuntudesign/documentation_builder/cli.py
@@ -58,6 +58,13 @@ def parse_arguments():
         help="Path to an alternate wrapping template for the built HTML files"
     )
     parser.add_argument(
+        '--site-root',
+        help=(
+            "A URL path to the root of the site, for use in the 'home' "
+            "link in the template."
+        )
+    )
+    parser.add_argument(
         '--media-url',
         help=(
             "Prefix for linking to media inside the built HTML files "

--- a/ubuntudesign/documentation_builder/resources/wrapper.jinja2
+++ b/ubuntudesign/documentation_builder/resources/wrapper.jinja2
@@ -24,11 +24,18 @@
     .js-collapsed .js-toggle-collapsed:before {
       content: '+';
     }
+    .p-navigation__logo {
+      font-weight: 400;
+      color: #000;
+    }
+    .p-navigation__link:hover {
+       text-decoration: none;
+    }
     .site-logo {
       vertical-align: middle;
       height: 28px;
-      margin-right: 5px;
-      margin-bottom: 4px;
+      margin-right: 0.5rem;
+      margin-bottom: 1px;
     }
     .p-toc__item {
       margin-bottom: 0.5em;
@@ -48,10 +55,10 @@
   <body class="theme">
     <header class="p-navigation" role="banner">
       <div class="p-navigation__logo">
-        {% if site_base_path %}<a class="p-navigation__link" href="/">{% endif %}
+        {% if site_root %}<a class="p-navigation__link" href="{{ site_root }}">{% endif %}
           {% if site_logo_url %}<img class="site-logo" src="{{ site_logo_url }}" alt="{{ site_title }} logo" />{% endif %}
           {{ site_title if site_title else 'Documentation' }}
-        {% if site_base_path %}</a>{% endif %}
+        {% if site_root %}</a>{% endif %}
       </div>
       <nav class="p-navigation__nav">
         <span class="u-off-screen">


### PR DESCRIPTION
`metadata.yaml` is a more descriptive name than the horribly generic `context.yaml` (fixes #21).

Also, add `--site-root` option, so you can specify the base link that the link in the header should take you back to. (fixes #22).

QA
--

In a set of documentation, rename `context.yaml` to `metadata.yaml`. Run the documentation builder, check it reads it properly.

Now play around with building with or without the `--site-root` option, and clicking the link in the top left of the site.