### PR TITLE
Ignore unmodified files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,5 +39,4 @@ Optional arguments:
         --media-url {prefix}              `# Prefix for linking to media inside the built HTML files (default: Relative path to built media location, e.g.: ../media)`
         --no-link-extensions              `# Don't include '.html' extension in internal links`
         --no-cleanup                      `# Don't clean up temporary directory after cloning repository`
-        --ignore-file                     `# Filename of a markdown files to ignore and not parse into HTML. Can be declared multiple times. (default: README.md)`
-
+        --quiet                           `# Suppress output`

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -229,10 +229,7 @@ class Builder:
             path.join(self.source_path, '**/*.md'),
             recursive=True
         ):
-            if path.basename(filepath) in self.ignore_files:
-                print("Ignored {}".format(filepath))
-            else:
-                self._build_file(filepath)
+            self._build_file(filepath)
 
     def _copy_media(self):
         """
@@ -264,6 +261,16 @@ class Builder:
         Create an HTML file for a documentation page from a path to the
         corresponding Markdown file
         """
+
+        # Ignore all uppercase filenames
+        name = path.splitext(path.basename(source_filepath))[0]
+        alphabet_name = re.sub(r'\W+', '', name)
+
+        if alphabet_name.isupper():
+            self._print("Skipping all-uppercase file: {}".format(
+                source_filepath
+            ))
+            return
 
         # Decide output filepath
         local_path = path.relpath(source_filepath, self.source_path)

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -180,7 +180,7 @@ class Builder:
         template,
         media_url,
         no_link_extensions,
-        ignore_files
+        quiet
     ):
         self.source_path = source_path
         self.source_media_path = source_media_path
@@ -189,7 +189,7 @@ class Builder:
         self.template = template
         self.media_url = media_url
         self.no_link_extensions = no_link_extensions
-        self.ignore_files = ignore_files
+        self.quiet = quiet
 
     def build(self):
         """
@@ -243,17 +243,18 @@ class Builder:
 
             if not media_paths_match:
                 mergetree(self.source_media_path, self.output_media_path)
-                print(
+                self._print(
                     "Copied {} to {}".format(
-                        self.source_media_path, self.output_media_path
+                        self.source_media_path,
+                        self.output_media_path
                     )
                 )
         else:
-            print(
+            self._print(
                 "Warning: Media directory not found at {}.".format(
                     self.source_media_path
                 ),
-                file=sys.stderr
+                channel=sys.stderr
             )
 
     def _build_file(self, source_filepath):
@@ -267,7 +268,7 @@ class Builder:
         alphabet_name = re.sub(r'\W+', '', name)
 
         if alphabet_name.isupper():
-            self._print("Skipping all-uppercase file: {}".format(
+            self._print("Skipping uppercase filename: {}".format(
                 source_filepath
             ))
             return
@@ -421,7 +422,15 @@ class Builder:
         with open(output_filepath, 'w') as output_file:
             output_file.write(html_document)
 
-        print("Created {output_filepath}".format(**locals()))
+        self._print("Created {output_filepath}".format(**locals()))
+
+    def _print(self, message, channel=sys.stdout):
+        """
+        Output a message unless quiet is on
+        """
+
+        if not self.quiet:
+            print(message, file=channel)
 
 
 def build(
@@ -435,14 +444,14 @@ def build(
     media_url=None,
     no_link_extensions=False,
     no_cleanup=False,
-    ignore_files=['README.md']
+    quiet=False
 ):
     with open(template_path or default_template) as template_file:
         template = Template(template_file.read())
 
     if repository:
         repo_dir = tempfile.mkdtemp()
-        print("Cloning {repository} into {repo_dir}".format(**locals()))
+        self._print("Cloning {repository} into {repo_dir}".format(**locals()))
         if branch:
             Repo.clone_from(repository, repo_dir, branch=branch)
         else:
@@ -459,11 +468,11 @@ def build(
             template=template,
             media_url=media_url,
             no_link_extensions=no_link_extensions,
-            ignore_files=ignore_files
+            quiet=quiet
         )
         builder.build()
 
     finally:
         if repository and not no_cleanup:
-            print("Cleaning up {repo_dir}".format(**locals()))
+            self._print("Cleaning up {repo_dir}".format(**locals()))
             rmtree(repo_dir)

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -281,6 +281,13 @@ class Builder:
             path.join(self.output_path, local_path)
         )
 
+        # Skip if it's unmodified
+        if path.exists(output_filepath) and (
+            path.getmtime(output_filepath) > path.getmtime(source_filepath)
+        ):
+            self._print("Skipping unmodified file: {}".format(source_filepath))
+            return
+
         # Get HTML
         html_document = self._build_html(source_filepath, output_filepath)
 

--- a/ubuntudesign/documentation_builder/cli.py
+++ b/ubuntudesign/documentation_builder/cli.py
@@ -75,14 +75,9 @@ def parse_arguments():
         help="Don't clean up temporary directory after cloning repository"
     )
     parser.add_argument(
-        '--ignore-file',
-        action='append',
-        default=['README.md'],
-        dest='ignore_files',
-        help=(
-            "Filename of a markdown file to ignore and not parse into HTML. "
-            "Can be declared multiple times."
-        )
+        '--quiet',
+        action='store_true',
+        help="Suppress output"
     )
     parser.add_argument(
         '--version',


### PR DESCRIPTION
Any files where the built file both exists and is newer than the source markdown file will be skipped.
This will help address #20, as subsequent builds should now take under a second.

I've also removed the `--ignore-files` option and added `--quiet`.

QA
---

Try it out:

``` bash
documentation-builder  # run this twice. Then try touching a markdown file and running it again.
documentation-builder --quiet  # Try this too
```