### PR TITLE
New option: --build-version-branches

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,25 +14,21 @@ Installation
 Usage
 -----
 
-The basic usage will build the markdown files from a remote repository
-in the standard format into the local directory:
+To build a local folder of markdown files in the appropriate format into HTML files:
 
 .. code:: bash
 
     $ documentation-builder  # Build markdown documentation from the current directory
-    # or
-    $ documentation-builder --repository git@github.com:juju/docs.git  # Build documentation from remote repository
 
 Optional arguments:
 
 .. code:: bash
 
     $ documentation-builder \
-        --repository {repository-url}     `# A source repository. If provided, all source paths will be relative to this repository root`
-        --branch {branch-name}            `# Pull from an alternative branch to the default (only valid with --repository)`
-        --source-path {dirpath}           `# Path to the folder containing markdown files (default: .)`
-        --source-media-dir {dirpath}      `# Path to the folder containing media files (default: ./media)`
-        --source-context-file {filepath}  `# A file containing the context object for building the templates (default: ./context.yaml)`
+        --base-directory {dirpath}        `# Path to the base folder for the documentation repository`
+        --source-folder {dirpath}         `# Path to the folder containing markdown files inside the base directory (default: .)`
+        --media-folder {dirpath}          `# Path to the folder containing media files inside the base directory (default: ./media)`
+        --site-root {local-url-path}      `# A URL path to the root of the site, for use in the 'home' link in the template`
         --output-path {dirpath}           `# Destination path for the built HTML files (default: ./build)`
         --output-media-path {dirpath}     `# Where to put media files (default: ./build/media)`
         --template-path {filepath}        `# Path to an alternate wrapping template for the built HTML files`

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ Optional arguments:
         --site-root {local-url-path}      `# A URL path to the root of the site, for use in the 'home' link in the template`
         --output-path {dirpath}           `# Destination path for the built HTML files (default: ./build)`
         --output-media-path {dirpath}     `# Where to put media files (default: ./build/media)`
+        --build-version-branches          `# Build each branch mentioned in the `versions` file into a subfolder`
         --template-path {filepath}        `# Path to an alternate wrapping template for the built HTML files`
         --media-url {prefix}              `# Prefix for linking to media inside the built HTML files (default: Relative path to built media location, e.g.: ../media)`
         --no-link-extensions              `# Don't include '.html' extension in internal links`

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Optional arguments:
     $ documentation-builder \
         --base-directory {dirpath}        `# Path to the base folder for the documentation repository`
         --source-folder {dirpath}         `# Path to the folder containing markdown files inside the base directory (default: .)`
-        --media-folder {dirpath}          `# Path to the folder containing media files inside the base directory (default: ./media)`
+        --media-path {dirpath}            `# Path to the folder containing media files (default: ./media)`
         --site-root {local-url-path}      `# A URL path to the root of the site, for use in the 'home' link in the template`
         --output-path {dirpath}           `# Destination path for the built HTML files (default: ./build)`
         --output-media-path {dirpath}     `# Where to put media files (default: ./build/media)`

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -454,10 +454,9 @@ class Builder:
 
 
 def build(
-    repository=None,
-    branch=None,
-    source_path='.',
-    source_media_dir='media',
+    base_directory='.',
+    source_folder='.',
+    media_folder='media',
     output_path='build',
     output_media_path='build/media',
     template_path=None,
@@ -470,31 +469,18 @@ def build(
     with open(template_path or default_template) as template_file:
         template = Template(template_file.read())
 
-    if repository:
-        repo_dir = tempfile.mkdtemp()
-        self._print("Cloning {repository} into {repo_dir}".format(**locals()))
-        if branch:
-            Repo.clone_from(repository, repo_dir, branch=branch)
-        else:
-            Repo.clone_from(repository, repo_dir)
+    source_path = path.normpath(path.join(base_directory, source_folder))
+    media_path = path.normpath(path.join(source_path, media_folder))
 
-        source_path = path.join(repo_dir, source_path)
-
-    try:
-        builder = Builder(
-            source_path=source_path,
-            source_media_path=path.join(source_path, source_media_dir),
-            output_path=output_path,
-            output_media_path=output_media_path,
-            template=template,
-            site_root=site_root,
-            media_url=media_url,
-            no_link_extensions=no_link_extensions,
-            quiet=quiet
-        )
-        builder.build()
-
-    finally:
-        if repository and not no_cleanup:
-            self._print("Cleaning up {repo_dir}".format(**locals()))
-            rmtree(repo_dir)
+    builder = Builder(
+        source_path=source_path,
+        source_media_path=media_path,
+        output_path=output_path,
+        output_media_path=output_media_path,
+        template=template,
+        site_root=site_root,
+        media_url=media_url,
+        no_link_extensions=no_link_extensions,
+        quiet=quiet
+    )
+    builder.build()

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -178,6 +178,7 @@ class Builder:
         output_path,
         output_media_path,
         template,
+        site_root,
         media_url,
         no_link_extensions,
         quiet
@@ -187,6 +188,7 @@ class Builder:
         self.output_path = output_path
         self.output_media_path = output_media_path
         self.template = template
+        self.site_root = site_root
         self.media_url = media_url
         self.no_link_extensions = no_link_extensions
         self.quiet = quiet
@@ -307,6 +309,10 @@ class Builder:
         metadata = self._build_metadata(source_filepath, output_filepath)
         metadata.update(local_metadata)
         metadata['content'] = html_content
+
+        if self.site_root:
+            metadata['site_root'] = self.site_root
+
         html_document = self.template.render(metadata)
 
         # Fixup internal references
@@ -441,6 +447,7 @@ def build(
     output_path='build',
     output_media_path='build/media',
     template_path=None,
+    site_root=None,
     media_url=None,
     no_link_extensions=False,
     no_cleanup=False,
@@ -466,6 +473,7 @@ def build(
             output_path=output_path,
             output_media_path=output_media_path,
             template=template,
+            site_root=site_root,
             media_url=media_url,
             no_link_extensions=no_link_extensions,
             quiet=quiet

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -456,7 +456,7 @@ class Builder:
 def build(
     base_directory='.',
     source_folder='.',
-    media_folder='media',
+    media_path='media',
     output_path='build',
     output_media_path='build/media',
     template_path=None,
@@ -470,7 +470,6 @@ def build(
         template = Template(template_file.read())
 
     source_path = path.normpath(path.join(base_directory, source_folder))
-    media_path = path.normpath(path.join(source_path, media_folder))
 
     builder = Builder(
         source_path=source_path,

--- a/ubuntudesign/documentation_builder/cli.py
+++ b/ubuntudesign/documentation_builder/cli.py
@@ -35,11 +35,11 @@ def parse_arguments():
         )
     )
     parser.add_argument(
-        '--media-folder',
+        '--media-path',
         default="media",
         help=(
-            "Path to the folder containing media files "
-            "inside the base directory (default: ./media)"
+            "Path to the folder containing media files relative to the current"
+            "directory (default: ./media)"
         )
     )
     parser.add_argument(

--- a/ubuntudesign/documentation_builder/cli.py
+++ b/ubuntudesign/documentation_builder/cli.py
@@ -22,27 +22,25 @@ def parse_arguments():
     )
 
     parser.add_argument(
-        '--repository',
-        help=(
-            "Build files from a remote repository instead of a local folder"
-        )
+        '--base-directory',
+        default=".",
+        help="The path to the base directory to build from."
     )
     parser.add_argument(
-        '--branch',
-        help=(
-            "Pull from an alternative branch to the default"
-            "Only valid with --repository."
-        )
-    )
-    parser.add_argument(
-        '--source-path',
+        '--source-folder',
         default='.',
-        help="Path to the folder containing markdown files (default: .)"
+        help=(
+            "Path to the folder containing the markdown source files "
+            "inside the base directory (default: .)"
+        )
     )
     parser.add_argument(
-        '--source-media-dir',
+        '--media-folder',
         default="media",
-        help="Path to the folder containing media files (default: ./media)"
+        help=(
+            "Path to the folder containing media files "
+            "inside the base directory (default: ./media)"
+        )
     )
     parser.add_argument(
         '--output-path',

--- a/ubuntudesign/documentation_builder/cli.py
+++ b/ubuntudesign/documentation_builder/cli.py
@@ -58,6 +58,13 @@ def parse_arguments():
         help="Path to an alternate wrapping template for the built HTML files"
     )
     parser.add_argument(
+        '--site-root',
+        help=(
+            "A URL path to the root of the site, for use in the 'home' "
+            "link in the template."
+        )
+    )
+    parser.add_argument(
         '--media-url',
         help=(
             "Prefix for linking to media inside the built HTML files "

--- a/ubuntudesign/documentation_builder/cli.py
+++ b/ubuntudesign/documentation_builder/cli.py
@@ -70,6 +70,14 @@ def parse_arguments():
         )
     )
     parser.add_argument(
+        '--build-version-branches',
+        action='store_true',
+        help=(
+            "Build each branch mentioned in the `versions` file into a "
+            "subfolder"
+        )
+    )
+    parser.add_argument(
         '--no-link-extensions',
         action='store_true',
         help="Don't include '.html' extension in internal links"

--- a/ubuntudesign/documentation_builder/resources/wrapper.jinja2
+++ b/ubuntudesign/documentation_builder/resources/wrapper.jinja2
@@ -24,11 +24,18 @@
     .js-collapsed .js-toggle-collapsed:before {
       content: '+';
     }
+    .p-navigation__logo {
+      font-weight: 400;
+      color: #000;
+    }
+    .p-navigation__link:hover {
+       text-decoration: none;
+    }
     .site-logo {
       vertical-align: middle;
       height: 28px;
-      margin-right: 5px;
-      margin-bottom: 4px;
+      margin-right: 0.5rem;
+      margin-bottom: 1px;
     }
     .p-toc__item {
       margin-bottom: 0.5em;
@@ -48,10 +55,10 @@
   <body class="theme">
     <header class="p-navigation" role="banner">
       <div class="p-navigation__logo">
-        {% if site_base_path %}<a class="p-navigation__link" href="/">{% endif %}
+        {% if site_root %}<a class="p-navigation__link" href="{{ site_root }}">{% endif %}
           {% if site_logo_url %}<img class="site-logo" src="{{ site_logo_url }}" alt="{{ site_title }} logo" />{% endif %}
           {{ site_title if site_title else 'Documentation' }}
-        {% if site_base_path %}</a>{% endif %}
+        {% if site_root %}</a>{% endif %}
       </div>
       <nav class="p-navigation__nav">
         <span class="u-off-screen">


### PR DESCRIPTION
If you supply the `--build-version-branches` flag, instead of looking for markdown files directly in the base directory,
it will look for a `versions` file of branches, check out each mentioned branch, and then build each of those branches into
a subdirectory in the build directory.

Fixes #5 and #11.

QA
--

Inside a repository with multiple branched, e.g.:

``` bash
$ git branch
master
1.0
1.1
```

Make sure there's a `versions` file mentioning those branches:

``` bash
$ cat versions
1.0
1.1
```

Now try it out:

``` bash
$ pip3 install {path-to-documentation-builder}
$ {path-to-documentation-builder}/bin/documentation-builder --build-version-branches
$ tree build
build
├── 1.0
│   └── en
│       └── index.html
└── 1.1
    └── en
        └── index.html
```