### PR TITLE
Implement tag-manager-code option

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -32,13 +32,15 @@ $ documentation-builder \
     --base-directory {dirpath}        `# Path to the base folder for the documentation repository`
     --source-folder {dirpath}         `# Path to the folder containing markdown files inside the base directory (default: .)`
     --media-path {dirpath}            `# Path to the folder containing media files (default: ./media)`
-    --site-root {local-url-path}      `# A URL path to the root of the site, for use in the 'home' link in the template`
     --output-path {dirpath}           `# Destination path for the built HTML files (default: ./build)`
     --output-media-path {dirpath}     `# Where to put media files (default: ./build/media)`
-    --build-version-branches          `# Build each branch mentioned in the `versions` file into a subfolder`
     --template-path {filepath}        `# Path to an alternate wrapping template for the built HTML files`
+    --site-root {root_path}           `# A URL path to the root of the site, for use in the 'home' link in the template (defaults to none)`
     --media-url {prefix}              `# Prefix for linking to media inside the built HTML files (default: Relative path to built media location, e.g.: ../media)`
+    --force                           `# Rebuild all files (assume all files have changed).`
+    --build-version-branches          `# Build each branch mentioned in the `versions` file into a subfolder`
     --no-link-extensions              `# Don't include '.html' extension in internal links`
     --no-cleanup                      `# Don't clean up temporary directory after cloning repository`
     --quiet                           `# Suppress output`
+    --version                         `# Show the currently installed version of documentation-builder`
 ```

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -37,6 +37,7 @@ $ documentation-builder \
     --template-path {filepath}        `# Path to an alternate wrapping template for the built HTML files`
     --site-root {root_path}           `# A URL path to the root of the site, for use in the 'home' link in the template (defaults to none)`
     --media-url {prefix}              `# Prefix for linking to media inside the built HTML files (default: Relative path to built media location, e.g.: ../media)`
+    --tag-manager-code {code}         `# If you supply a tag manager code, the default template will render Google tag manager snippets into the built HTML.`
     --force                           `# Rebuild all files (assume all files have changed).`
     --build-version-branches          `# Build each branch mentioned in the `versions` file into a subfolder`
     --no-link-extensions              `# Don't include '.html' extension in internal links`

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ assert sys.version_info >= (3, 5), (
 
 setup(
     name='ubuntudesign.documentation-builder',
-    version='1.0.0',
+    version='1.0.1',
     author='Canonical webteam',
     author_email='robin+pypi@canonical.com',
     url='https://github.com/ubuntudesign/documentation-builder',

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: documentation-builder
-version: '1.0.0'
+version: '1.0.1'
 summary: Build HTML documentation from markdown
 description: |
   A tool to build repositories of markdown files of documentation into HTML pages

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -279,6 +279,43 @@ def test_media_url():
     rmtree(output)
 
 
+def test_tag_manager():
+    base = path.join(fixtures_path, 'builder', 'base')
+    output = path.join(fixtures_path, 'builder', 'output')
+    index_filepath = path.join(
+        fixtures_path, 'builder', 'output', 'en', 'index.html'
+    )
+    if path.exists(output):
+        rmtree(output)
+
+    Builder(
+        base_directory=base,
+        output_path=output,
+        tag_manager_code='GTM_654321',
+        quiet=True
+    )
+
+    with open(index_filepath) as index_file:
+        index_content = index_file.read()
+        assert 'googletagmanager.com' in index_content
+        assert 'GTM_654321' in index_content
+
+    rmtree(output)
+
+    Builder(
+        base_directory=base,
+        output_path=output,
+        quiet=True
+    )
+
+    with open(index_filepath) as index_file:
+        index_content = index_file.read()
+        assert 'googletagmanager.com' not in index_content
+        assert 'GTM_654321' not in index_content
+
+    rmtree(output)
+
+
 def _compare_trees(directory_a, directory_b):
     a_files = []
     b_files = []

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -192,20 +192,24 @@ class Builder():
         if built_files:
             self._print("Built:\n- {}".format('\n- '.join(built_files)))
 
-        try:
-            if copy_media(media_path, output_media_path):
-                self._print(
-                    "Copied {} to {}".format(media_path, output_media_path)
+        if path.isdir(media_path):
+            copy_media(media_path, output_media_path)
+            self._print(
+                "Copied {} to {}".format(media_path, output_media_path)
+            )
+        else:
+            self._note(
+                "No folder found at '{}' - not copying media".format(
+                    media_path
                 )
-        except EnvironmentError as copy_error:
-            self._warn("Copying media failed: " + str(copy_error))
+            )
 
     def _print(self, message, channel=None):
         if not self.quiet:
             print(message, file=channel or self._out)
 
-    def _warn(self, message):
-        self._print("Warning: " + message, channel=self._err)
+    def _note(self, message):
+        self._print("Notice: " + message, channel=self._err)
 
     def _fail(self, message):
         self._print("Error: " + message, channel=self._err)

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -62,6 +62,7 @@ class Builder():
         template_path=default_template,
         site_root=None,
         media_url=None,
+        tag_manager_code=None,
         no_link_extensions=False,
         no_cleanup=False,
         quiet=False,
@@ -149,6 +150,7 @@ class Builder():
                     path.relpath(file_directory, branch_source)
                 )
                 metadata['site_root'] = site_root
+                metadata['tag_manager_code'] = tag_manager_code
 
                 navigation = metadata.get('navigation')
 

--- a/ubuntudesign/documentation_builder/cli.py
+++ b/ubuntudesign/documentation_builder/cli.py
@@ -74,6 +74,13 @@ def parse_arguments():
         )
     )
     parser.add_argument(
+        '--tag-manager-code',
+        help=(
+            "If you supply a tag manager code, the default template will "
+            "render Google tag manager snippets into the built HTML."
+        )
+    )
+    parser.add_argument(
         '--force',
         action="store_true",
         help=("Rebuild all files (assume all files have changed)")

--- a/ubuntudesign/documentation_builder/cli.py
+++ b/ubuntudesign/documentation_builder/cli.py
@@ -104,7 +104,7 @@ def parse_arguments():
     parser.add_argument(
         '--version',
         action='store_true',
-        help="Show the currently installed version"
+        help="Show the currently installed version of documentation-builder."
     )
 
     arguments = vars(parser.parse_args())

--- a/ubuntudesign/documentation_builder/operations.py
+++ b/ubuntudesign/documentation_builder/operations.py
@@ -137,7 +137,7 @@ def find_metadata(directory_path):
     return metadata_items
 
 
-def parse_markdown(parser, template, filepath, metadata):
+def parse_markdown(parser, template, filepath, metadata, tag_manager_code=None):
     parser.reset()
     metadata = deepcopy(metadata)
 

--- a/ubuntudesign/documentation_builder/operations.py
+++ b/ubuntudesign/documentation_builder/operations.py
@@ -137,7 +137,7 @@ def find_metadata(directory_path):
     return metadata_items
 
 
-def parse_markdown(parser, template, filepath, metadata, tag_manager_code=None):
+def parse_markdown(parser, template, filepath, metadata):
     parser.reset()
     metadata = deepcopy(metadata)
 

--- a/ubuntudesign/documentation_builder/resources/template.html
+++ b/ubuntudesign/documentation_builder/resources/template.html
@@ -1,6 +1,16 @@
 <!doctype html>
 <html lang="en">
   <head>
+    {% if tag_manager_code %}
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','{{ tag_manager_code }}');</script>
+    <!-- End Google Tag Manager -->
+    {% endif %}
+
     <meta charset="UTF-8" />
     <title>{{ site_title if site_title else 'Documentation' }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -162,6 +172,13 @@
     </style>
   </head>
   <body class="theme">
+    {% if tag_manager_code %}
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ tag_manager_code }}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    {% endif %}
+
     <header class="theme__header p-navigation" role="banner">
       <div class="p-navigation__logo">
         {% if site_root %}<a class="p-navigation__link" href="{{ site_root }}">{% endif %}


### PR DESCRIPTION
An option to put google-tag-manager code in the built HTML files.

Including all tests.

Fixes #34.

QA
--

Try building documentation with `--tag-manager-code=GTM_xxxxxx` and see the tag manager code in the built HTML files.