### PR TITLE
Use the defined page meta title

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,3 +2,4 @@ v1.2.0, 2017-02-09 -- Add syntax highlighting
 v1.2.1, 2017-02-10 -- Bugfix: Fix styling to prevent checkbox showing where it should't
 v1.2.2, 2017-02-21 -- Upgrade to vanilla-docs-theme 1.3.3 in the default template
 v1.3.0, 2017-02-22 -- Add search form to template, enabled with "--search-url"
+v1.3.1, 2017-02-22 -- Include page title in <title> in the default template

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ assert sys.version_info >= (3, 5), (
 
 setup(
     name='ubuntudesign.documentation-builder',
-    version='1.3.0',
+    version='1.3.1',
     author='Canonical webteam',
     author_email='robin+pypi@canonical.com',
     url='https://github.com/ubuntudesign/documentation-builder',

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: documentation-builder
-version: '1.3.0'
+version: '1.3.1'
 summary: Build HTML documentation from markdown
 description: |
   A tool to build repositories of markdown files of documentation into HTML pages

--- a/tests/fixtures/builder/output_basic/en/index.html
+++ b/tests/fixtures/builder/output_basic/en/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title>Index page | The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_basic/en/subfolder/nested.html
+++ b/tests/fixtures/builder/output_basic/en/subfolder/nested.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title>Nested page | The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_basic/fr/index.html
+++ b/tests/fixtures/builder/output_basic/fr/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title> | The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_media_path/en/index.html
+++ b/tests/fixtures/builder/output_media_path/en/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title>Index page | The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_media_path/en/subfolder/nested.html
+++ b/tests/fixtures/builder/output_media_path/en/subfolder/nested.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title>Nested page | The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_media_path/fr/index.html
+++ b/tests/fixtures/builder/output_media_path/fr/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title> | The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_media_url/en/index.html
+++ b/tests/fixtures/builder/output_media_url/en/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title>Index page | The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_media_url/en/subfolder/nested.html
+++ b/tests/fixtures/builder/output_media_url/en/subfolder/nested.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title>Nested page | The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_media_url/fr/index.html
+++ b/tests/fixtures/builder/output_media_url/fr/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title> | The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_no_media/en/index.html
+++ b/tests/fixtures/builder/output_no_media/en/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title>Index page | The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_no_media/en/subfolder/nested.html
+++ b/tests/fixtures/builder/output_no_media/en/subfolder/nested.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title>Nested page | The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_no_media/fr/index.html
+++ b/tests/fixtures/builder/output_no_media/fr/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title> | The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_search/en/index.html
+++ b/tests/fixtures/builder/output_search/en/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title>Index page | The title of my site</title>
   </head>
   <body class="theme">
     <form id="search" action="https://example.com/search" class="search--header">

--- a/tests/fixtures/builder/output_search/en/subfolder/nested.html
+++ b/tests/fixtures/builder/output_search/en/subfolder/nested.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title>Nested page | The title of my site</title>
   </head>
   <body class="theme">
     <form id="search" action="https://example.com/search" class="search--header">

--- a/tests/fixtures/builder/output_search/fr/index.html
+++ b/tests/fixtures/builder/output_search/fr/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>The title of my site</title>
+    <title> | The title of my site</title>
   </head>
   <body class="theme">
     <form id="search" action="https://example.com/search" class="search--header">

--- a/tests/fixtures/builder/output_versions/1.0/en/index.html
+++ b/tests/fixtures/builder/output_versions/1.0/en/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>1.0: The title of my site</title>
+    <title>Index page | 1.0: The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_versions/1.0/en/subfolder/nested.html
+++ b/tests/fixtures/builder/output_versions/1.0/en/subfolder/nested.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>1.0: The title of my site</title>
+    <title>Nested page | 1.0: The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_versions/1.0/fr/index.html
+++ b/tests/fixtures/builder/output_versions/1.0/fr/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>1.0: The title of my site</title>
+    <title> | 1.0: The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_versions/latest/en/index.html
+++ b/tests/fixtures/builder/output_versions/latest/en/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>latest: The title of my site</title>
+    <title>Index page | latest: The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_versions/latest/en/subfolder/nested.html
+++ b/tests/fixtures/builder/output_versions/latest/en/subfolder/nested.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>latest: The title of my site</title>
+    <title>Nested page | latest: The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/tests/fixtures/builder/output_versions/latest/fr/index.html
+++ b/tests/fixtures/builder/output_versions/latest/fr/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>latest: The title of my site</title>
+    <title> | latest: The title of my site</title>
   </head>
   <body class="theme">
     <nav class="p-sidebar-nav">

--- a/ubuntudesign/documentation_builder/resources/template.html
+++ b/ubuntudesign/documentation_builder/resources/template.html
@@ -12,7 +12,7 @@
     {% endif %}
 
     <meta charset="UTF-8" />
-    <title>{{ site_title if site_title else 'Documentation' }}</title>
+    <title>{{ title }} | {{ site_title if site_title else 'Documentation' }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       /* vanilla-docs-theme 1.3.4 */


### PR DESCRIPTION
Fixes #58 by adding the title from the Markdown metadata to the meta title markup element.

QA
--

Build a set of documentation with this new version:

``` bash
git clone https://github.com/canonicalltd/ubuntu-core-docs
cd ubuntu-core-docs
python3 -m venv env
git clone -b 58-meta-title https://github.com/nottrobin/documentation-builder
env/bin/pip install ./documentation-builder
env/bin/python3 ./documentation-builder/bin/documentation-builder
```

Now open up `build/en/index.html`, or any other page, and see that the `<title>` value is now of the format `[page_title] | [site title]`.