### PR TITLE
Add development instructions to the README.rst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tests/fixtures/prepare_branches/repo/
 tests/fixtures/builder/base-repo/
 .coverage
 htmlcov/
+env*/

--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,40 @@ Installation
 
 For more information see `the documentation <docs/en/>`__.
 
+Development
+-----------
+
+documentation-builder is a Python module. The main application code lives in
+`ubuntudesign/documentation_builder <ubuntudesign/documentation_builder>`__. Updates
+to the markup or styling should be made in `the default template <ubuntudesign/documentation_builder/resources/template.html>`__.
+
+Checking changes
+~~~~~~~~~~~~~~~~
+
+To check your changes to documentation-builder, it's probably easiest to install the module locally, in editable mode, within an encapsulated environment:
+
+.. code:: bash
+
+    python3 -m venv env3 && source env3/bin/activate  # Create encapsulated environment
+    pip install -e .  # Install the module in editable mode
+
+    bin/documentation-builder --source-folder docs  # build the documentation-builder's own documentation
+    xdg-open build/en/index.html  # Open up the documentation page
+
+Watching for changes
+~~~~~~~~~~~~~~~~~~~~
+
+On Ubuntu et al. you can use `inotifywait` to watch for changes to the source files, and rebuild when something changes as follows:
+
+.. code:: bash
+
+    sudo apt install inotify-tools  # Ensure inotifywait is installed
+
+    # Force rebuild docs when anything changes in the source folder
+    while inotifywait -r -e close_write "./ubuntudesign"; do bin/documentation-builder --force --source-folder docs; done
+
 Tests
-----
+~~~~~
 
 To run tests:
 


### PR DESCRIPTION
Also ignore the `env3/` directory that these instructions suggest you
generate.

QA
---

Try following the [development instructions](https://github.com/nottrobin/documentation-builder/tree/development-instructions#Development).