### PR TITLE
Use standard admonition extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         "Jinja2==2.8",
         "Markdown==2.6.6",
         "mdx-anchors-away==1.0.1",
-        "mdx-callouts==1.0.0",
         "mdx-foldouts==1.0.0",
         "python-frontmatter==0.2.1",
         "pygments==2.2.0",

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -12,7 +12,8 @@ from markdown.extensions.meta import MetaExtension
 from markdown.extensions.tables import TableExtension
 from markdown.extensions.toc import TocExtension
 from markdown.extensions.codehilite import CodeHiliteExtension
-from mdx_callouts import makeExtension as CalloutsExtension
+from markdown.extensions.admonition import AdmonitionExtension
+#from mdx_callouts import makeExtension as CalloutsExtension
 from mdx_anchors_away import AnchorsAwayExtension
 from mdx_foldouts import makeExtension as FoldoutsExtension
 
@@ -45,7 +46,7 @@ markdown_extensions = [
     DefListExtension(),
     AttrListExtension(),
     TocExtension(marker='', baselevel=1),
-    CalloutsExtension(),
+    AdmonitionExtension(),
     CodeHiliteExtension(),
     AnchorsAwayExtension(),
     FoldoutsExtension()

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -13,7 +13,6 @@ from markdown.extensions.tables import TableExtension
 from markdown.extensions.toc import TocExtension
 from markdown.extensions.codehilite import CodeHiliteExtension
 from markdown.extensions.admonition import AdmonitionExtension
-#from mdx_callouts import makeExtension as CalloutsExtension
 from mdx_anchors_away import AnchorsAwayExtension
 from mdx_foldouts import makeExtension as FoldoutsExtension
 


### PR DESCRIPTION
Replace mdxCallouts with standard admonition extension
Fixes #62 

# QA

perform the following steps:

```
git clone https://github.com/canonicalltd/maas-docs
cd maas-docs
python3 -m venv env
git clone -b admonition https://github.com/evilnick/documentation-builder
env/bin/pip install ./documentation-builder
env/bin/python3 ./documentation-builder/bin/documentation-builder
```

Search the generated doc ` build/en/index.html ` for:

```
<div class="admonition note">
<p class="admonition-title">Note</p>
</div>
<p>Windows, RHEL and SUSE images require
<a href="https://www.ubuntu.com/support">Ubuntu Advantage</a> to work properly with MAAS. </p>
```
which replaces the current:

```
<p class="note"><strong> Note</strong>: Windows, RHEL and SUSE images require
<a href="https://www.ubuntu.com/support">Ubuntu Advantage</a> to work properly with MAAS. </p>
```
Also note the following, which uses a different class for the type of admonition:

```
<div class="admonition warning">
<p class="admonition-title">Warning</p>
</div>
<p>A machine destined for MAAS will have its disk space overwritten.
A node in the pool is under MAAS's sole control and should not be provisioned
using other methods.</p>
```

N.B. This isn't ideal - the current admontions will need to be slightly rewritten in the text to properly take advantage of the opportunity to style the text (the `<p>` will end up inside the `<div>`), however, it doesn't break the current behaviour in the meantime as there are no styles.