### PR TITLE
Add urlize to convert text links to anchor links

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,4 +4,4 @@ v1.2.2, 2017-02-21 -- Upgrade to vanilla-docs-theme 1.3.3 in the default templat
 v1.3.0, 2017-02-22 -- Add search form to template, enabled with "--search-url"
 v1.3.1, 2017-02-22 -- Include page title in <title> in the default template
 v1.4.0, 2017-03-21 -- Support for notifications in documents
-
+v1.4.2, 2017-03-30 -- Add urlize to convert text links to anchor links

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ assert sys.version_info >= (3, 5), (
 
 setup(
     name='ubuntudesign.documentation-builder',
-    version='1.4.1',
+    version='1.4.2',
     author='Canonical webteam',
     author_email='robin+pypi@canonical.com',
     url='https://github.com/ubuntudesign/documentation-builder',
@@ -39,6 +39,7 @@ setup(
         "pygments==2.2.0",
         "PyYAML==3.12",
         "beautifulsoup4==4.5.1",
+        "markdown_urlize==0.2.0",
     ],
     setup_requires=['pytest-runner'],
     tests_require=[

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: documentation-builder
-version: '1.4.1'
+version: '1.4.2'
 summary: Build HTML documentation from markdown
 description: |
   A tool to build repositories of markdown files of documentation into HTML pages

--- a/ubuntudesign/documentation_builder/builder.py
+++ b/ubuntudesign/documentation_builder/builder.py
@@ -12,6 +12,7 @@ from markdown.extensions.meta import MetaExtension
 from markdown.extensions.tables import TableExtension
 from markdown.extensions.toc import TocExtension
 from markdown.extensions.codehilite import CodeHiliteExtension
+from mdx_urlize import UrlizeExtension
 from mdx_anchors_away import AnchorsAwayExtension
 from mdx_foldouts import makeExtension as FoldoutsExtension
 
@@ -48,7 +49,8 @@ markdown_extensions = [
     NotificationsExtension(),
     CodeHiliteExtension(),
     AnchorsAwayExtension(),
-    FoldoutsExtension()
+    FoldoutsExtension(),
+    UrlizeExtension(),
 ]
 
 


### PR DESCRIPTION
Done
---
Added markdown_urlize==0.2.0 as a dependency. Bumped the version.

QA
---
- Pull this branch
- Go to maas-docs repo
- Run the steps listed in [checking changes](https://github.com/CanonicalLtd/documentation-builder#checking-changes)
- Open /build/en/contributing.html
- Check that the text links are no HTML links

Details
---
Fixes https://github.com/CanonicalLtd/documentation-builder/issues/68