### PR TITLE
Fix nav wrapping

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,3 +5,4 @@ v1.3.0, 2017-02-22 -- Add search form to template, enabled with "--search-url"
 v1.3.1, 2017-02-22 -- Include page title in <title> in the default template
 v1.4.0, 2017-03-21 -- Support for notifications in documents
 v1.4.2, 2017-03-30 -- Add urlize to convert text links to anchor links
+v1.4.3, 2017-03-30 -- Use the site_logo as a favicon; Styling improvement for wrapping in navigation

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ assert sys.version_info >= (3, 5), (
 
 setup(
     name='ubuntudesign.documentation-builder',
-    version='1.4.2',
+    version='1.4.3',
     author='Canonical webteam',
     author_email='robin+pypi@canonical.com',
     url='https://github.com/ubuntudesign/documentation-builder',

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: documentation-builder
-version: '1.4.2'
+version: '1.4.3'
 summary: Build HTML documentation from markdown
 description: |
   A tool to build repositories of markdown files of documentation into HTML pages

--- a/ubuntudesign/documentation_builder/resources/template.html
+++ b/ubuntudesign/documentation_builder/resources/template.html
@@ -234,6 +234,17 @@
         display: block;
       }
 
+      .p-sidebar-nav__header {
+        position: relative;
+        padding-right: 1rem;
+      }
+
+      .p-sidebar-nav__toggle--expand,
+      .p-sidebar-nav__toggle--collapse {
+        position: absolute;
+        right: 0;
+      }
+
       @media (min-width: 768px) {
         .theme__sidebar-toggle-button {
           background-image: url('https://assets.ubuntu.com/v1/39a96c62-navigation-menu-black.svg');


### PR DESCRIPTION
QA
--

``` bash
git clone https://github.com/canonicalltd/docs-landscape
cd docs-landscape
git clone -b fix-navigation-wrapping https://github.com/nottrobin/documentation-builder
python3 -m venv env3
env3/bin/pip install ./documentation-builder
env3/bin/python ./documentation-builder/bin/documentation-builder
```

Now open `build/en/index.html` and check the "Landscape On-Premises" navigation item wraps more sensibly.